### PR TITLE
update version number to v1.0.8 in Cargo.lock, too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "nat"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "ansi_term",
  "chrono",


### PR DESCRIPTION
(after this, you might want to re-set the `v1.0.8` tag once more)