### PR TITLE
Resetting default terminal color after last line

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
           .paint(e.file_name().unwrap().to_str().unwrap())
       );
     }
+    print!("{}", color::Fg(color::Reset));
   }
   Ok(())
 }


### PR DESCRIPTION
Otherwise, the last color setting may remain after the exit of nat