### PR TITLE
Using release build for installation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,9 @@ users = "*"
 pretty-bytes = "*"
 ansi_term = "*"
 structopt = "*"
+
+[profile.dev]
+opt-level = 0
+
+[profile.release]
+opt-level = 3

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ cd /tmp
 git clone https://github.com/willdoescode/nat.git
 cd /tmp/nat
 
-cargo build
+cargo build --release
 
-cd target/debug
+cd target/release
 
 ./nat
 ```


### PR DESCRIPTION
Using the optimized release build for installation, documented for Linux and added optimization options for devel and release profiles in cargo configuration