### PR TITLE
Remove git source from snapcraft.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.idea
 /linux
 /macOs
+*.snap

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -16,7 +16,7 @@ base: core20
 parts:
   natls:
     plugin: rust
-    source: https://github.com/willdoescode/nat.git
+    source: .
     build-packages:
       - gcc-multilib
 


### PR DESCRIPTION
# Summary

- Since the `snapcraft.yaml` is now on the repo it is not necessary to use an external source.
- Ignore `*.snap` to avoid commiting the file :) 

# QA

- `snapcraft`
- `snap install --dangerous natls_1.2.10_amd64.snap`
- `natls`
- Should work as usual!