### PR TITLE
Simplify brew install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ cargo install natls
 ## Homebrew
 
 ```bash
-brew tap willdoescode/homebrew-natls
-
-brew install natls
+brew install willdoescode/natls/natls
 ```
 
 ### Alternative (linux)


### PR DESCRIPTION
1. Brew now supports directly tapping while installing
2. The `homebrew` prefix while specifying tap is unnecessary (in fact, the docs mention that taps exclude that prefix)