### PR TITLE
Improve display

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -34,7 +34,7 @@ pub struct Cli {
   pub long: bool,
 
   /// Formats the time output 
-  #[structopt(long = "time-format", default_value = "%e %b %T")]
+  #[structopt(long = "time-format", default_value = "%e %b %H.%M")]
   pub time_format: String,
 
   /// Shows the file created time instead of the file modified time

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,7 @@ impl Directory {
             .unwrap()
           )
       }),
-      DirSortType::Size     => sort_as(&mut self.paths, |a, b| {
+      DirSortType::Size => sort_as(&mut self.paths, |a, b| {
         a.path
           .symlink_metadata()
           .unwrap()
@@ -266,7 +266,7 @@ impl Directory {
             .size()
           )
       }),
-      DirSortType::Not      => (),
+      DirSortType::Not => (),
     }
   }
 
@@ -299,15 +299,15 @@ impl Directory {
       let uhold = self.paths[p].user.to_owned();
       let shold = self.paths[p].size.to_owned();
       let mut gwidth = String::new();
-      for _ in 0..(gs - ghold.len()) {
-        gwidth.push(' ')
+      for _ in 0..(gs - ghold.len() + 1) {
+        gwidth.push(' ');
       }
       let mut uwidth = String::new();
-      for _ in 0..(us - uhold.len()) {
+      for _ in 0..(us - uhold.len() + 1) {
         uwidth.push(' ')
       }
       let mut swidth = String::new();
-      for _ in 0..(ss - shold.len()) {
+      for _ in 0..(ss - shold.len() + 1) {
         swidth.push(' ')
       }
       self.paths[p].group = format!("{}{}", ghold, gwidth);


### PR DESCRIPTION
This PR improves the output of the `nat -l` command by doing the following:

- Formatting the time as per `ls -l` (01.23)
- Adding a padding between the columns

![image](https://user-images.githubusercontent.com/4939519/111085318-2667a200-8517-11eb-8701-c59bc5164d68.png)
